### PR TITLE
Fix bugs to sort the output VCF

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -2,8 +2,8 @@
     "name": "eggd_add_MANE_annotation",
     "title": "eggd_add_MANE_annotation",
     "summary": "Adds extra MANE info to VCF as a flag",
-    "dxapi": "1.0.0",
-    "version": "1.0.0",
+    "dxapi": "1.1.0",
+    "version": "1.1.0",
     "inputSpec": [
         {
         "name": "input_vcf_annotated",

--- a/resources/home/dnanexus/vcf.py
+++ b/resources/home/dnanexus/vcf.py
@@ -267,7 +267,7 @@ def check_written_out_vcf(
     )
 
 
-def bcftools_sort(input_vcf_decompressed):
+def bcftools_sort(input_vcf_decompressed, output_vcf):
     """
     Sort the VCF. As we write out variants in gene order, if a
     variant is annotated to multiple genes/transcripts and split, we can end up
@@ -282,7 +282,7 @@ def bcftools_sort(input_vcf_decompressed):
 
     Outputs
     -------
-    {vcf}.sorted.vcf : file
+    {vcf}.mane.flagged.sorted.vcf : file
         sorted vcf file output from bcftools
 
     Raises
@@ -292,7 +292,7 @@ def bcftools_sort(input_vcf_decompressed):
     """
     
     print(f"Sorting flagged VCF {input_vcf_decompressed} with bcftools sort")
-    output_vcf = f"{Path(input_vcf_decompressed).stem.split('.')[0]}.sorted.vcf"
+    output_vcf = f"{Path(input_vcf_decompressed).stem.split('.')[0]}.mane.flagged.sorted.vcf"
 
     # Check total rows before running bcftools sort
     pre_sort_total = subprocess.run(
@@ -376,7 +376,7 @@ def add_annotation(input_vcf_decompressed, transcript_file, transcript_file_tabl
     """
     split_vcf = f"{Path(input_vcf_decompressed).stem.split('.')[0]}.split.vcf"
     MANE_flagged_vcf = f"{Path(input_vcf_decompressed).stem.split('.')[0]}.mane.flagged.vcf"
-    sorted_vcf = f"{Path(input_vcf_decompressed).stem.split('.')[0]}.sorted.vcf"
+    sorted_vcf = f"{Path(input_vcf_decompressed).stem.split('.')[0]}.mane.flagged.sorted.vcf"
 
   
     # separate csq fields (creates split_vcf)
@@ -389,9 +389,9 @@ def add_annotation(input_vcf_decompressed, transcript_file, transcript_file_tabl
     transcript_variant_dict = add_MANE_field(vcf_contents, transcript_file_table)
     write_out_flagged_vcf(MANE_flagged_vcf, transcript_variant_dict, vcf_contents)
     check_written_out_vcf(vcf_contents, transcript_variant_dict, MANE_flagged_vcf)
-    bcftools_sort(MANE_flagged_vcf)
+    bcftools_sort(MANE_flagged_vcf, sorted_vcf)
 
-    bgzip(MANE_flagged_vcf)
+    bgzip(sorted_vcf)
     os.remove(split_vcf)
     os.remove(sorted_vcf)
 


### PR DESCRIPTION
In the previous version of the app, the output VCF was not being sorted by `bcftools_sort` function, so changes are made to ensure correct sorting.
Changes:

- updated the app version from 1.0.0 to 1.1.0
- in `bcftools_sort` function: added an argument, updated description, renamed the output VCF
- in `add_annotation` function: renamed the output (sorted) VCF, added an argument when calling `bcftools_sort`, zipped the correct file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_add_MANE_annotation/5)
<!-- Reviewable:end -->
